### PR TITLE
Update Fluree test client, example for data constraint policy

### DIFF
--- a/fluree-proxy/jest.config.js
+++ b/fluree-proxy/jest.config.js
@@ -6,4 +6,10 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'js'],
   testMatch: ['**/tests/**/*.test.ts'],
+  setupFiles: [],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
 };

--- a/fluree-proxy/server.ts
+++ b/fluree-proxy/server.ts
@@ -2,12 +2,13 @@ import { serve } from "bun";
 import { FlureeClient } from "@fluree/fluree-client";
 
 const dbHost = process.env.DB_HOST || 'localhost';
+const createLedger = (process.env.CREATE_LEDGER === 'true');
 
 const client = await new FlureeClient({
   host: dbHost,
   port: 58090,
-  ledger: 'cryptids',
-  // create: true
+  ledger: 'mwb2',
+  create: createLedger
 }).connect();
 
 const server = serve({

--- a/fluree-proxy/testClient.ts
+++ b/fluree-proxy/testClient.ts
@@ -1,14 +1,136 @@
 import fetch from "node-fetch";
+import { v4 as uuidv4 } from 'uuid';
 
-async function testFlureeProxy() {
-  const query = {
-    // from: "cryptids",
-    select: { '?s': ['*'] },
-    where: {
-      '@id': '?s',
-    },
-  };
+const query = {
+  // from: "cryptids",
+  "@context": {
+    "@vocab": "https://meaningfy.ws/mapping-workbench/",
+    "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+    "mwb": "http://meaningfy.ws/mapping-workbench/",
+    "schema": "http://schema.org/",
+    "sh": "http://www.w3.org/ns/shacl#"
+  },
+  select: { '?s': ['*'] },
+  where: {
+    '@id': '?s',
+    '@type': "mwb:Project"
+  },
+};
 
+const transaction = {
+  "@context": {
+    "@vocab": "https://meaningfy.ws/mapping-workbench/",
+    "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+    "mwb": "http://meaningfy.ws/mapping-workbench/",
+    "schema": "http://schema.org/",
+    "sh": "http://www.w3.org/ns/shacl#"
+  },
+  insert: {
+    "@id": uuidv4(),
+    "@type": "mwb:Project",
+    "schema:name": "MWB2 Periodic",
+  }
+};
+
+const transactionViolation = {
+  "@context": {
+    "@vocab": "https://meaningfy.ws/mapping-workbench/",
+    "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+    "mwb": "http://meaningfy.ws/mapping-workbench/",
+    "schema": "http://schema.org/",
+    "sh": "http://www.w3.org/ns/shacl#"
+  },
+  insert: {
+    "@id": "mwb1",
+    "@type": "mwb:Project",
+    "schema:name": "MWB1.2",
+  }
+};
+
+const policy = {
+  "@context": {
+    "@vocab": "https://meaningfy.ws/mapping-workbench/",
+    "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+    "mwb": "http://meaningfy.ws/mapping-workbench/",
+    "schema": "http://schema.org/",
+    "sh": "http://www.w3.org/ns/shacl#"
+  },
+  "insert": [
+      {
+        "@id": "ex:ProjectShape",
+        "@type": ["sh:NodeShape"],
+        "sh:targetClass": { "@id": "mwb:Project" },
+        "sh:property": [
+          {
+            "sh:path": { "@id": "schema:name" },
+            "sh:maxCount": 1
+          }
+        ]
+      },
+      {
+        "@id": "mwb1",
+        "@type": "mwb:Project",
+        "schema:name": "MWB1",
+        "schema:description": "This is an eForms Project"
+      }
+  ]
+}
+
+async function testFlureeProxyWritePolicy() {
+  try {
+    const response = await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(policy, null, 2)
+    });
+
+    const data = await response.json();
+
+    console.log("Response from Fluree Proxy for WritePolicy:", data);
+  } catch (error) {
+    console.error("Error testing Fluree Proxy:", error);
+  }
+}
+
+async function testFlureeProxyWriteData() {
+  try {
+    const response = await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(transaction, null, 2)
+    });
+
+    const data = await response.json();
+
+    console.log("Response from Fluree Proxy for WriteData:", data);
+  } catch (error) {
+    console.error("Error testing Fluree Proxy:", error);
+  }
+}
+
+async function testFlureeProxyWriteViolation() {
+  try {
+    const response = await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(transactionViolation, null, 2)
+    });
+
+    const data = await response.json();
+
+    console.log("Response from Fluree Proxy for WriteViolation:", data);
+  } catch (error) {
+    console.error("Error testing Fluree Proxy:", error);
+  }
+}
+
+async function testFlureeProxyReadData() {
   try {
     const response = await fetch("http://localhost:3000/query", {
       method: "POST",
@@ -19,10 +141,14 @@ async function testFlureeProxy() {
     });
 
     const data = await response.json();
-    console.log("Response from Fluree Proxy:", data);
+
+    console.log("Response from Fluree Proxy for ReadData:", data);
   } catch (error) {
     console.error("Error testing Fluree Proxy:", error);
   }
 }
 
-testFlureeProxy();
+// testFlureeProxyWritePolicy();
+testFlureeProxyWriteData();
+testFlureeProxyReadData();
+testFlureeProxyWriteViolation();

--- a/fluree-proxy/tests/server.test.ts
+++ b/fluree-proxy/tests/server.test.ts
@@ -1,4 +1,6 @@
 import fetch from "node-fetch";
+import { v4 as uuidv4 } from 'uuid';
+import { describe, it, expect } from '@jest/globals';
 
 describe("Fluree Proxy Server", () => {
   it("should return available routes at the root endpoint", async () => {
@@ -76,7 +78,6 @@ describe("Fluree Proxy Server", () => {
     expect(data).toBeDefined();
     // Add more assertions based on expected data structure
   });
-  });
 
   it("should handle a valid transact request", async () => {
     const transaction = {
@@ -100,3 +101,160 @@ describe("Fluree Proxy Server", () => {
     expect(data.commit).toBeDefined();
     // Add more assertions based on expected data structure
   });
+
+  it("should handle a valid query request with JSON-LD context", async () => {
+    const query = {
+      "@context": {
+        "@vocab": "https://meaningfy.ws/mapping-workbench/",
+        "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+        "mwb": "http://meaningfy.ws/mapping-workbench/",
+        "schema": "http://schema.org/",
+        "sh": "http://www.w3.org/ns/shacl#"
+      },
+      select: { '?s': ['*'] },
+      where: {
+        '@id': '?s',
+        '@type': "mwb:Project"
+      },
+    };
+
+    const response = await fetch("http://localhost:3000/query", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(query, null, 2)
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toBeDefined();
+  });
+
+  it("should handle a valid transact request with JSON-LD context", async () => {
+    const transaction = {
+      "@context": {
+        "@vocab": "https://meaningfy.ws/mapping-workbench/",
+        "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+        "mwb": "http://meaningfy.ws/mapping-workbench/",
+        "schema": "http://schema.org/",
+        "sh": "http://www.w3.org/ns/shacl#"
+      },
+      insert: {
+        "@id": uuidv4(),
+        "@type": "mwb:Project",
+        "schema:name": "Test Project"
+      }
+    };
+
+    const response = await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(transaction, null, 2)
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.commit).toBeDefined();
+  });
+
+  it("should handle a valid policy transaction with combined data", async () => {
+    const policy = {
+      "@context": {
+        "@vocab": "https://meaningfy.ws/mapping-workbench/",
+        "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+        "mwb": "http://meaningfy.ws/mapping-workbench/",
+        "schema": "http://schema.org/",
+        "sh": "http://www.w3.org/ns/shacl#"
+      },
+      "insert": [
+        {
+          "@id": "ex:ProjectShape",
+          "@type": ["sh:NodeShape"],
+          "sh:targetClass": { "@id": "mwb:Project" },
+          "sh:property": [
+            {
+              "sh:path": { "@id": "schema:name" },
+              "sh:maxCount": 1
+            }
+          ]
+        },
+        {
+          "@id": "test-policy-project",
+          "@type": "mwb:Project",
+          "schema:name": "Test Policy Project",
+          "schema:description": "This is a test project for policy"
+        }
+      ]
+    };
+
+    const response = await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(policy, null, 2)
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.commit).toBeDefined();
+  });
+
+  it("should reject any transaction that violates policy constraints", async () => {
+    // First create a project with ID "policy-violation-test"
+    const initialTransaction = {
+      "@context": {
+        "@vocab": "https://meaningfy.ws/mapping-workbench/",
+        "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+        "mwb": "http://meaningfy.ws/mapping-workbench/",
+        "schema": "http://schema.org/",
+        "sh": "http://www.w3.org/ns/shacl#"
+      },
+      insert: {
+        "@id": "policy-violation-test",
+        "@type": "mwb:Project",
+        "schema:name": "Initial Project"
+      }
+    };
+
+    await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(initialTransaction, null, 2)
+    });
+
+    // Now try to update it with a duplicate ID, which should violate constraints
+    const violationTransaction = {
+      "@context": {
+        "@vocab": "https://meaningfy.ws/mapping-workbench/",
+        "@base": "https://meaningfy.ws/data-centric-app-demo/",      
+        "mwb": "http://meaningfy.ws/mapping-workbench/",
+        "schema": "http://schema.org/",
+        "sh": "http://www.w3.org/ns/shacl#"
+      },
+      insert: {
+        "@id": "policy-violation-test",
+        "@type": "mwb:Project",
+        "schema:name": "Duplicate Project"
+      }
+    };
+
+    const response = await fetch("http://localhost:3000/transact", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(violationTransaction, null, 2)
+    });
+
+    // The response might be 400 or 409 depending on how your server handles violations
+    expect([400, 409, 500]).toContain(response.status);
+    const data = await response.json();
+    expect(data.error || data.message).toBeDefined();
+  });
+});


### PR DESCRIPTION
- Distinct functions for testing read and writes
- Additional write function for constraint testing
- Separate data for each function
- Write data with random UUID to keep inserting anew
- Proper namespaces and prefixes via JSON-LD `@context`

If you try to submit a Project with the same ID twice but with a different name, the constraint on the name will be violated. Fluree returns a HTTP 422, but if the proxy doesn't handle that, it will be a 500.

The write test will keep writing the same entity with different random IDs. You will see that entity on subsequent runs, not in the same run that both the read and write occur.

The violation write will fail, as the violation is triggered with the same data as the policy write, which is commented out (run it uncommented once).

A reminder that if you have errors starting Fluree with Docker, change the data volume name and create the ledger anew.

Note: We will move this example somewhere else when deleting the Bun proxy in favour of the Express one. Let's keep it here for now.